### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   release:
     name: build and publish to docker hub


### PR DESCRIPTION
Potential fix for [https://github.com/pfandie/drone-ci-aws-elastic-beanstalk/security/code-scanning/1](https://github.com/pfandie/drone-ci-aws-elastic-beanstalk/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily interacts with DockerHub and does not require write access to the repository, we will set `contents: read` at the workflow level. This ensures that the workflow has minimal permissions while still being able to perform its tasks. If additional permissions are required for specific jobs, they can be added at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
